### PR TITLE
fix(path): use relative paths only for HTML

### DIFF
--- a/templates/root.html
+++ b/templates/root.html
@@ -1,14 +1,14 @@
 <html>
   <head>
     <title>Folium Map Custom URL Override Submission</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/bootstrap-4.4.1.min.css') }}">
+    <link rel="stylesheet" href="./static/css/bootstrap-4.4.1.min.css">
   </head>
   <body>
     <div class="container">
       <h2 class="mt-4">Folium Map Custom URL Override Submission</h2>
       <div class="card">
         <div class="card-body">
-          <form action="{{ url_for('main.generate') }}" method="post" enctype="multipart/form-data" class="needs-validation" novalidate>
+          <form action="./generate" method="post" enctype="multipart/form-data" class="needs-validation" novalidate>
             <div class="form-group row">
               <label class="col-sm-3 col-form-label" for="folium_host">Custom folium host:</label>
               <input


### PR DESCRIPTION
This makes the entire site hostable on non-root path.