### PR TITLE
feat(env): allow env vars to override app config

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,6 @@
+FLASK_APP_COMPRESS_LEVEL=9
+FLASK_APP_COMPRESS_ALGORITHM=["gzip"]
+
 APP_DEFAULT_FOLIUM_SERVER_URL=http://localhost:8080
 APP_DEFAULT_TILESERVER_GL_URL=http://localhost:9090
 APP_TILESERVER_GL_TILES=dark_matter,fiord,klokantech_3d,klokantech_basic,klokantech_terrain,osm_bright,osm_liberty,positron,toner

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ docker-compose up --build
 
 In your web browser, go to <http://localhost:8000>.
 
+## App config via environment variables
+
+The webserver set-up dynamically picks up all `FLASK_APP_` prefixed env vars to be assigned into the
+`app.config`. For e.g., if you set the env var `FLASK_APP_COMPRESS_LEVEL=9`, the webservice would do
+`app.config['COMPRESS_LEVEL'] = 9`.
+
+The value to assign can be a JSON string if you need to assign a list, e.g.:
+`FLASK_APP_COMPRESS_ALGORITHM='["gzip"]'`.
+
+Currently this webservice has the following packages that require app config set-up:
+
+- [Flask-Compress](https://pypi.org/project/Flask-Compress/)
+
 ## Versioning
 
 The tag release system here follows this format `vX.Y.Z_folium-v0.10.1`. The`vX.Y.Z` part is the

--- a/app.py
+++ b/app.py
@@ -5,13 +5,13 @@ $ python app.py
 And then head to http://127.0.0.1:5000/ in your browser to see the map displayed
 """
 
+import json
 import os
+from typing import Dict
 
 from dotenv import load_dotenv
 from flask import Flask
 from flask_compress import Compress
-import json
-from typing import Dict
 
 import fover.api.main as api_main
 

--- a/app.py
+++ b/app.py
@@ -10,8 +10,24 @@ import os
 from dotenv import load_dotenv
 from flask import Flask
 from flask_compress import Compress
+import json
+from typing import Dict
 
 import fover.api.main as api_main
+
+
+def setup_app_conf(app: Flask, prefix: str) -> None:
+    envs = {k: v for k, v in os.environ.items() if k.startswith(prefix) and v}
+
+    for k, v in envs.items():
+        key = k[len(prefix) :]  # Strip the prefix
+
+        try:
+            app.config[key] = json.loads(v)
+        except ValueError as e:
+            # Value is a raw string
+            app.config[key] = v
+
 
 load_dotenv()
 
@@ -19,10 +35,10 @@ load_dotenv()
 #                   Defaults to the name of the static_folder folder.
 # static_folder – the folder with static files that should be served at static_url_path.
 #                 Defaults to the 'static' folder in the root path of the application.
+FLASK_APP_ENV_PREFIX = "FLASK_APP_"
 app = Flask(__name__)
-app.config["COMPRESS_LEVEL"] = 9
-app.config["COMPRESS_ALGORITHM"] = ["gzip"]
 
+setup_app_conf(app, FLASK_APP_ENV_PREFIX)
 Compress(app)
 
 app.register_blueprint(api_main.bp)


### PR DESCRIPTION
Allow all "FLASK_APP_" prefixed env vars to be used to override the app
config values dynamically.

Update the README with app config explanation.